### PR TITLE
Adds ModMenu `library` badge.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,5 +29,10 @@
   "depends": {
   },
   "suggests": {
+  },
+  "custom": {
+    "modmenu": {
+      "badges": [ "library" ]
+    }
   }
 }


### PR DESCRIPTION
This allows to filter library mods in [ModMenu](https://github.com/TerraformersMC/ModMenu/wiki/API#badges).