### PR TITLE
Set `EmbeddedChannel` for fake `ClientConnection`s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,10 @@ publishing {
 	repositories {
 		maven {
 			url "https://maven.cafeteria.dev/releases"
-			credentials {
-				username = project.property("mcdUsername")
-				password = project.property("mcdPassword")
-			}
+			//credentials {
+			//	username = project.property("mcdUsername")
+			//	password = project.property("mcdPassword")
+			//}
 			authentication {
 				basic(BasicAuthentication)
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -79,15 +79,19 @@ publishing {
 
 	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
 	repositories {
-		maven {
-			url "https://maven.cafeteria.dev/releases"
-			//credentials {
-			//	username = project.property("mcdUsername")
-			//	password = project.property("mcdPassword")
-			//}
-			authentication {
-				basic(BasicAuthentication)
+		if (project.hasProperty("mcdUsername") && project.hasProperty("mcdPassword")) {
+			maven {
+				url "https://maven.cafeteria.dev/releases"
+				credentials {
+					username = project.property("mcdUsername")
+					password = project.property("mcdPassword")
+				}
+				authentication {
+					basic(BasicAuthentication)
+				}
 			}
+		} else {
+			println("Repo credentials not present, not configuring publishing repositories.")
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.14.8
 fabric_version=0.58.5+1.19.1
 
 # Mod Properties
-mod_version = 0.5.0
+mod_version = 1.5.0
 maven_group = dev.cafeteria
 archives_base_name = fakeplayerapi
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.14.8
 fabric_version=0.58.5+1.19.1
 
 # Mod Properties
-mod_version = 1.5.0
+mod_version = 0.5.0
 maven_group = dev.cafeteria
 archives_base_name = fakeplayerapi
 

--- a/src/main/java/dev/cafeteria/fakeplayerapi/mixin/ClientConnectionAccessor.java
+++ b/src/main/java/dev/cafeteria/fakeplayerapi/mixin/ClientConnectionAccessor.java
@@ -1,0 +1,12 @@
+package dev.cafeteria.fakeplayerapi.mixin;
+
+import io.netty.channel.Channel;
+import net.minecraft.network.ClientConnection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientConnection.class)
+public interface ClientConnectionAccessor {
+    @Accessor
+    void setChannel(Channel channel);
+}

--- a/src/main/java/dev/cafeteria/fakeplayerapi/server/FakeClientConnection.java
+++ b/src/main/java/dev/cafeteria/fakeplayerapi/server/FakeClientConnection.java
@@ -1,8 +1,8 @@
 package dev.cafeteria.fakeplayerapi.server;
 
+import dev.cafeteria.fakeplayerapi.mixin.ClientConnectionAccessor;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.channel.embedded.EmbeddedChannel;
 import net.minecraft.class_7648;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.network.NetworkSide;
@@ -20,6 +20,7 @@ public class FakeClientConnection extends ClientConnection {
 
     public FakeClientConnection(NetworkSide side) {
         super(side);
+        ((ClientConnectionAccessor) this).setChannel(new EmbeddedChannel());
     }
 
     @Override

--- a/src/main/resources/fake-player-api.mixins.json
+++ b/src/main/resources/fake-player-api.mixins.json
@@ -4,6 +4,7 @@
   "package": "dev.cafeteria.fakeplayerapi.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "ClientConnectionAccessor",
     "EntityMixin",
     "TargetPredicateMixin",
     "PlayerAdvancementTrackerMixin",


### PR DESCRIPTION
Fixes #1 and #4 by following the vanilla nullability contract

Tested on 1.19.2 with [`mods-command`](https://modrinth.com/mod/mods-command), which uses [`adventure-platform-fabric`](https://github.com/KyoriPowered/adventure-platform-fabric/), and [`Create`](https://github.com/Fabricators-of-Create/Create), which uses `fake-player-api` for Deployers, seen in the screenshot below
<img width="984" alt="Screenshot 2023-03-22 at 8 08 52 PM" src="https://user-images.githubusercontent.com/11360596/227091203-a90124c6-63d4-46f8-9557-2b169a86822d.png">

A very similar fix has been applied to Carpet Mod and ComputerCraft quite a while ago, so there shouldn't be any risk of this causing problems.

Also modified the build script to not error when you don't have repo credentials